### PR TITLE
feat: Add Navan AI page for Spec Coding Consulting

### DIFF
--- a/webhook-server/app/navan-ai/page.tsx
+++ b/webhook-server/app/navan-ai/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from 'next';
+import Header from '../../components/Header';
+import Footer from '../../components/Footer';
+
+export const metadata: Metadata = {
+  title: 'Navan AI - Spec Coding Consulting',
+  description: 'Navan AI provides Spec Coding Consulting services. Visit navan.ai to learn more.',
+  openGraph: {
+    title: 'Navan AI - Spec Coding Consulting',
+    description: 'Navan AI provides Spec Coding Consulting services.',
+    url: 'https://1000pages.navan.ai/navan-ai',
+  },
+};
+
+export default function NavanAIPage() {
+  return (
+    <>
+      <Header />
+
+      <main>
+        <section className="hero">
+          <div className="hero-content">
+            <h1 className="hero-title">Navan AI</h1>
+            <p className="hero-subtitle">
+              Navan AI provides Spec Coding Consulting
+            </p>
+            <p className="hero-subtitle">
+              <a
+                href="https://navan.ai"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hero-link"
+              >
+                Visit navan.ai
+              </a>
+            </p>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </>
+  );
+}

--- a/webhook-server/app/page.tsx
+++ b/webhook-server/app/page.tsx
@@ -45,6 +45,14 @@ export default function Home() {
             </a>
           </div>
         </section>
+
+        <section className="cta-section">
+          <div className="cta-content">
+            <a href="/navan-ai" className="cta-button">
+              Visit Navan AI - Spec Coding Consulting
+            </a>
+          </div>
+        </section>
       </main>
 
       <Footer />

--- a/webhook-server/app/sitemap.ts
+++ b/webhook-server/app/sitemap.ts
@@ -14,5 +14,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'monthly',
       priority: 0.8,
     },
+    {
+      url: 'https://1000pages.navan.ai/navan-ai',
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
   ];
 }


### PR DESCRIPTION
## Summary
- Create new page at `/navan-ai/` for Navan AI - Spec Coding Consulting
- Add SEO metadata with OpenGraph support for better social sharing
- Update sitemap.xml with Navan AI entry for SEO
- Add navigation link from homepage to Navan AI page

## Test plan
- [x] Page renders correctly at `/navan-ai/`
- [x] SEO metadata is present in page source
- [x] Sitemap includes Navan AI URL
- [x] Homepage shows link to Navan AI page
- [x] Build completes successfully with static export
- [x] Dark/light theme toggle works (uses existing CSS variables)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)