### PR TITLE
feat: Convert 2nd section CTA button to hyperlink

### DIFF
--- a/webhook-server/app/globals.css
+++ b/webhook-server/app/globals.css
@@ -379,6 +379,44 @@ main {
   transform: translateY(0);
 }
 
+/* CTA Link - hyperlink style for CTA sections */
+.cta-link {
+  color: var(--color-primary-indigo);
+  text-decoration: none;
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  position: relative;
+  transition: color var(--transition-fast);
+}
+
+.cta-link::after {
+  content: '';
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--gradient-primary);
+  transform: scaleX(0);
+  transform-origin: right;
+  transition: transform var(--transition-normal);
+}
+
+.cta-link:hover {
+  color: var(--color-primary-purple);
+}
+
+.cta-link:hover::after {
+  transform: scaleX(1);
+  transform-origin: left;
+}
+
+.cta-link:focus {
+  outline: 2px solid var(--color-primary-indigo);
+  outline-offset: 4px;
+  border-radius: var(--radius-sm);
+}
+
 /* Footer */
 .footer {
   padding: var(--spacing-xl);

--- a/webhook-server/app/page.tsx
+++ b/webhook-server/app/page.tsx
@@ -31,9 +31,9 @@ export default function Home() {
               href="https://github.com/navan-ai/1000pages/issues/new"
               target="_blank"
               rel="noopener noreferrer"
-              className="cta-button"
+              className="cta-link"
             >
-              <span>Create a new page on 1000pages.navan.ai</span>
+              Create a new page on 1000pages.navan.ai
             </a>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- Adds new `.cta-link` CSS class with animated underline hover effect (matching `.hero-link` pattern)
- Updates 2nd section CTA from button style to hyperlink style
- Removes unnecessary `<span>` wrapper from 2nd section link

## Changes
- `webhook-server/app/globals.css`: Added `.cta-link` styles with hover/focus states
- `webhook-server/app/page.tsx`: Changed 2nd section from `cta-button` to `cta-link` class

## Test Plan
- [x] Build passes successfully (`npm run build`)
- [x] 2nd section displays as a hyperlink with animated underline on hover
- [x] 3rd and 4th sections remain as styled buttons (unchanged)
- [x] Focus states work correctly for accessibility

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)