### PR TITLE
feat: Convert CTA buttons to hyperlinks

### DIFF
--- a/webhook-server/app/globals.css
+++ b/webhook-server/app/globals.css
@@ -317,7 +317,7 @@ main {
 
 /* CTA Section */
 .cta-section {
-  padding: var(--spacing-3xl) var(--spacing-xl);
+  padding: var(--spacing-2xl) var(--spacing-xl);
   background-color: var(--color-bg-secondary);
   display: flex;
   justify-content: center;
@@ -329,54 +329,48 @@ main {
   text-align: center;
 }
 
-.cta-button {
-  display: inline-block;
-  padding: var(--spacing-lg) var(--spacing-2xl);
-  background: var(--gradient-primary);
-  color: var(--color-btn-text);
+/* CTA Link - Hyperlink styling for CTA sections */
+.cta-link {
+  color: var(--color-primary-indigo);
   text-decoration: none;
-  font-size: var(--font-size-lg);
+  font-size: var(--font-size-xl);
   font-weight: 600;
-  border-radius: var(--radius-xl);
-  box-shadow: var(--shadow-lg);
-  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
   position: relative;
-  overflow: hidden;
+  transition: color var(--transition-fast);
+  padding: var(--spacing-sm) 0;
+  display: inline-block;
 }
 
-.cta-button::before {
+.cta-link::after {
   content: '';
   position: absolute;
-  inset: 0;
-  background: var(--color-btn-hover);
-  opacity: 0;
-  transition: opacity var(--transition-fast);
-  border-radius: inherit;
-  z-index: 1;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--gradient-primary);
+  transform: scaleX(0);
+  transform-origin: right;
+  transition: transform var(--transition-normal);
 }
 
-.cta-button:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-xl);
-  color: var(--color-btn-text);
+.cta-link:hover {
+  color: var(--color-primary-purple);
 }
 
-.cta-button:hover::before {
-  opacity: 1;
+.cta-link:hover::after {
+  transform: scaleX(1);
+  transform-origin: left;
 }
 
-.cta-button span {
-  position: relative;
-  z-index: 2;
-}
-
-.cta-button:focus {
+.cta-link:focus {
   outline: 2px solid var(--color-primary-indigo);
   outline-offset: 4px;
+  border-radius: var(--radius-sm);
 }
 
-.cta-button:active {
-  transform: translateY(0);
+.cta-link:active {
+  opacity: 0.8;
 }
 
 /* Footer */
@@ -410,9 +404,8 @@ main {
     font-size: var(--font-size-lg);
   }
 
-  .cta-button {
-    padding: var(--spacing-md) var(--spacing-xl);
-    font-size: var(--font-size-base);
+  .cta-link {
+    font-size: var(--font-size-lg);
   }
 }
 
@@ -434,12 +427,11 @@ main {
   }
 
   .cta-section {
-    padding: var(--spacing-2xl) var(--spacing-md);
+    padding: var(--spacing-xl) var(--spacing-md);
   }
 
-  .cta-button {
-    padding: var(--spacing-md) var(--spacing-lg);
-    width: 100%;
-    text-align: center;
+  .cta-link {
+    font-size: var(--font-size-base);
+    padding: var(--spacing-md) 0;
   }
 }

--- a/webhook-server/app/page.tsx
+++ b/webhook-server/app/page.tsx
@@ -31,25 +31,25 @@ export default function Home() {
               href="https://github.com/navan-ai/1000pages/issues/new"
               target="_blank"
               rel="noopener noreferrer"
-              className="cta-button"
+              className="cta-link"
             >
-              <span>Create a new page on 1000pages.navan.ai</span>
+              Create a new page on 1000pages.navan.ai
             </a>
           </div>
         </section>
 
         <section className="cta-section">
           <div className="cta-content">
-            <a href="/saaragh" className="cta-button">
-              <span>Visit Saaragh - Spec Coding Consulting</span>
+            <a href="/saaragh" className="cta-link">
+              Visit Saaragh - Spec Coding Consulting
             </a>
           </div>
         </section>
 
         <section className="cta-section">
           <div className="cta-content">
-            <a href="/navan-ai" className="cta-button">
-              <span>Visit Navan AI - Spec Coding Consulting</span>
+            <a href="/navan-ai" className="cta-link">
+              Visit Navan AI - Spec Coding Consulting
             </a>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- Converts the 3 CTA buttons in the homepage's 2nd sections to styled hyperlinks
- Replaces `.cta-button` class with new `.cta-link` class featuring animated underline on hover
- Removes unnecessary `<span>` wrappers from links
- Cleans up unused `.cta-button` CSS rules

## Changes
| File | Description |
|------|-------------|
| `webhook-server/app/page.tsx` | Changed class from `cta-button` to `cta-link`, removed `<span>` wrappers |
| `webhook-server/app/globals.css` | Added `.cta-link` styles, removed `.cta-button` styles, adjusted responsive rules |

## Contrast & Accessibility
- Light theme: `#4F46E5` (indigo) on `#F9FAFB` background - hover: `#7C3AED` (purple)
- Dark theme: `#818CF8` on `#1E293B` background - hover: `#A78BFA`
- Focus state includes visible outline for keyboard navigation
- Proper touch targets on mobile via padding

## Test plan
- [ ] Verify all 3 hyperlinks render correctly on homepage
- [ ] Check hover state shows animated underline effect
- [ ] Test focus state shows proper outline
- [ ] Verify dark mode contrast is readable
- [ ] Test responsive behavior on mobile/tablet

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)