### PR TITLE
feat: Add Google link to 2nd section of homepage

### DIFF
--- a/webhook-server/app/page.tsx
+++ b/webhook-server/app/page.tsx
@@ -40,6 +40,19 @@ export default function Home() {
 
         <section className="cta-section">
           <div className="cta-content">
+            <a
+              href="https://google.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="cta-link"
+            >
+              Visit Google
+            </a>
+          </div>
+        </section>
+
+        <section className="cta-section">
+          <div className="cta-content">
             <a href="/saaragh" className="cta-link">
               Visit Saaragh - Spec Coding Consulting
             </a>


### PR DESCRIPTION
## Summary
- Adds a new CTA section with a link to Google (https://google.com/) in the 2nd section of the homepage
- Uses existing `.cta-link` class for consistent styling with animated underline hover effect
- Includes proper security attributes (`target="_blank"`, `rel="noopener noreferrer"`)

## Test plan
- [ ] Verify the Google link appears after the "Create a new page" link
- [ ] Verify clicking the link opens https://google.com/ in a new tab
- [ ] Verify hover animation matches other CTA links
- [ ] Test responsiveness at mobile (480px), tablet (768px), and desktop viewports

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)